### PR TITLE
Refactor form hooks and error handling

### DIFF
--- a/src/hooks/useContactForm.js
+++ b/src/hooks/useContactForm.js
@@ -2,68 +2,97 @@ import { useState } from "react";
 import DOMPurify from "dompurify";
 import emailjs from "emailjs-com";
 
+const isValidEmail = (email) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+
+const validateContactForm = ({ name, email, message }) => {
+  const errors = {};
+
+  if (!name.trim()) {
+    errors.name = "Name is required";
+  }
+
+  if (!email.trim()) {
+    errors.email = "Email is required";
+  } else if (!isValidEmail(email)) {
+    errors.email = "Invalid email format";
+  }
+
+  if (!message.trim()) {
+    errors.message = "Message is required";
+  }
+
+  return errors;
+};
+
+// Sanitize user input before sending it to EmailJS so the payload stays predictable.
+const sanitizeContactFormData = ({ name, email, message }) => ({
+  name: `Name: ${DOMPurify.sanitize(name)}`,
+  email: `Email: ${DOMPurify.sanitize(email)}`,
+  message: `Message: ${DOMPurify.sanitize(message)}`,
+});
+
+// Keep the EmailJS env lookup in one place so submit logic stays focused on state changes.
+const getEmailJsConfig = () => {
+  const {
+    REACT_APP_EMAILJS_SERVICE_ID: serviceID,
+    REACT_APP_EMAILJS_TEMPLATE_ID: templateID,
+    REACT_APP_EMAILJS_USER_ID: userID,
+  } = process.env;
+
+  return {
+    serviceID,
+    templateID,
+    userID,
+  };
+};
+
 export const useContactForm = (initialState) => {
   const [formData, setFormData] = useState(initialState);
   const [errors, setErrors] = useState({});
   const [isLoading, setIsLoading] = useState(false);
   const [isSent, setIsSent] = useState(false);
+  const [submitError, setSubmitError] = useState("");
 
   const handleChange = ({ target: { name, value } }) => {
+    // Clear stale submit failures once the user starts editing toward a retry.
+    setSubmitError("");
     setFormData((prevFormData) => ({
       ...prevFormData,
       [name]: value,
     }));
   };
 
-  const validateForm = () => {
-    const { name, email, message } = formData;
-    const newErrors = {};
-
-    if (!name.trim()) newErrors.name = "Name is required";
-    if (!email.trim()) {
-      newErrors.email = "Email is required";
-    } else if (!isValidEmail(email)) {
-      newErrors.email = "Invalid email format";
-    }
-    if (!message.trim()) newErrors.message = "Message is required";
-
-    return newErrors;
-  };
-
-  const isValidEmail = (email) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
-
   const handleSubmit = (e) => {
     e.preventDefault();
-    const validateErrors = validateForm();
+    const validateErrors = validateContactForm(formData);
+
     if (Object.keys(validateErrors).length) {
       setErrors(validateErrors);
       return;
     }
 
     setIsLoading(true);
+    setErrors({});
+    setSubmitError("");
 
-    const sanitizedData = {
-      name: `Name: ${DOMPurify.sanitize(formData.name)}`,
-      email: `Email: ${DOMPurify.sanitize(formData.email)}`,
-      message: `Message: ${DOMPurify.sanitize(formData.message)}`,
-    };
-
-    const {
-      REACT_APP_EMAILJS_SERVICE_ID: serviceID,
-      REACT_APP_EMAILJS_TEMPLATE_ID: templateID,
-      REACT_APP_EMAILJS_USER_ID: userID,
-    } = process.env;
+    const sanitizedData = sanitizeContactFormData(formData);
+    const { serviceID, templateID, userID } = getEmailJsConfig();
 
     emailjs
       .send(serviceID, templateID, sanitizedData, userID)
       .then(({ text }) => {
         console.log("Email sent successfully!", text);
+        // Reset the form after a successful send so the success state is the only thing left on screen.
         setFormData(initialState);
         setErrors({});
+        setSubmitError("");
         setIsSent(true);
       })
       .catch((error) => {
         console.error("Email sending failed", error);
+        setSubmitError(
+          "Something went wrong while sending your message. Please try again."
+        );
       })
       .finally(() => {
         setIsLoading(false);
@@ -75,6 +104,7 @@ export const useContactForm = (initialState) => {
     errors,
     isLoading,
     isSent,
+    submitError,
     handleChange,
     handleSubmit,
   };

--- a/src/hooks/useEmailGate.js
+++ b/src/hooks/useEmailGate.js
@@ -2,48 +2,61 @@ import { useEffect, useState } from "react";
 
 const EMAIL_GATE_STORAGE_KEY = "chatbot_email_gate";
 
+const getDefaultEmailGateState = () => ({
+  email: "",
+  emailSubmitted: false,
+});
+
+// Read and normalize the saved gate state so the hook always starts from one shape.
+const readEmailGateState = () => {
+  try {
+    const saved = localStorage.getItem(EMAIL_GATE_STORAGE_KEY);
+
+    if (!saved) {
+      return getDefaultEmailGateState();
+    }
+
+    const parsed = JSON.parse(saved);
+
+    return {
+      email: parsed.email || "",
+      emailSubmitted: Boolean(parsed.emailSubmitted && parsed.email),
+    };
+  } catch {
+    return getDefaultEmailGateState();
+  }
+};
+
+const writeEmailGateState = ({ email, emailSubmitted }) => {
+  localStorage.setItem(
+    EMAIL_GATE_STORAGE_KEY,
+    JSON.stringify({
+      email,
+      emailSubmitted,
+    })
+  );
+};
+
+const isValidEmail = (email) => /^[^@]+@[^@]+\.[^@]+$/.test(email);
+
 const useEmailGate = () => {
-  const [emailSubmitted, setEmailSubmitted] = useState(() => {
-    try {
-      const saved = localStorage.getItem(EMAIL_GATE_STORAGE_KEY);
-      if (!saved) {
-        return false;
-      }
-
-      const parsed = JSON.parse(saved);
-      return Boolean(parsed.emailSubmitted && parsed.email);
-    } catch {
-      return false;
-    }
-  });
-  const [email, setEmail] = useState(() => {
-    try {
-      const saved = localStorage.getItem(EMAIL_GATE_STORAGE_KEY);
-      if (!saved) {
-        return "";
-      }
-
-      const parsed = JSON.parse(saved);
-      return parsed.email || "";
-    } catch {
-      return "";
-    }
-  });
+  const initialState = readEmailGateState();
+  const [emailSubmitted, setEmailSubmitted] = useState(
+    initialState.emailSubmitted
+  );
+  const [email, setEmail] = useState(initialState.email);
   const [error, setError] = useState("");
 
+  // Persist the gate state so assistant access survives refreshes and route changes.
   useEffect(() => {
-    localStorage.setItem(
-      EMAIL_GATE_STORAGE_KEY,
-      JSON.stringify({
-        email,
-        emailSubmitted,
-      })
-    );
+    writeEmailGateState({
+      email,
+      emailSubmitted,
+    });
   }, [email, emailSubmitted]);
 
   const handleEmailSubmit = () => {
-    const isValid = /^[^@]+@[^@]+\.[^@]+$/.test(email);
-    if (isValid) {
+    if (isValidEmail(email)) {
       setError("");
       setEmailSubmitted(true);
     } else {

--- a/src/pages/chatbot/ChatbotMenu.jsx
+++ b/src/pages/chatbot/ChatbotMenu.jsx
@@ -21,7 +21,7 @@ const ChatbotMenu = () => {
       {!emailSubmitted ? (
         <EmailGate
           email={email}
-          setEmail={setEmail}
+          onEmailChange={setEmail}
           error={error}
           onSubmit={handleEmailSubmit}
         />

--- a/src/pages/chatbot/EmailGate.jsx
+++ b/src/pages/chatbot/EmailGate.jsx
@@ -1,6 +1,6 @@
 import "../../styles/emailGate.css";
 
-const EmailGate = ({ email, setEmail, error, onSubmit }) => {
+const EmailGate = ({ email, onEmailChange, error, onSubmit }) => {
   return (
     <div className="email-gate">
       <div className="email-intro-box">
@@ -17,7 +17,7 @@ const EmailGate = ({ email, setEmail, error, onSubmit }) => {
             type="email"
             className="email-input"
             value={email}
-            onChange={(e) => setEmail(e.target.value)}
+            onChange={(e) => onEmailChange(e.target.value)}
             onKeyDown={(e) => e.key === "Enter" && onSubmit()}
             placeholder="your@email.com"
             aria-label="Email input"

--- a/src/pages/contact/ContactMenu.jsx
+++ b/src/pages/contact/ContactMenu.jsx
@@ -8,8 +8,15 @@ const ContactMenu = () => {
     message: "",
   };
 
-  const { formData, errors, isLoading, isSent, handleChange, handleSubmit } =
-    useContactForm(initialState);
+  const {
+    formData,
+    errors,
+    isLoading,
+    isSent,
+    submitError,
+    handleChange,
+    handleSubmit,
+  } = useContactForm(initialState);
 
   return (
     <div className="contact-menu fade-in">
@@ -63,6 +70,11 @@ const ContactMenu = () => {
               <span className="error-message">{errors.message}</span>
             )}
           </div>
+          {submitError && (
+            <p className="error-message" role="alert">
+              {submitError}
+            </p>
+          )}
           <TooltipWrapper title="Ask for Resume/CV if needed">
             <button type="submit" disabled={isLoading}>
               {isLoading ? "SENDING..." : "SUBMIT"}


### PR DESCRIPTION
## Summary

This PR refactors the chatbot email gate and contact form hooks to reduce mixed responsibilities, clarify form state transitions, and surface contact form submission failures in the UI.

## What Changed

- Refactored [src/hooks/useEmailGate.js](/Users/johnnytrinh/.codex/worktrees/dec4/react-portfolio/src/hooks/useEmailGate.js)
  - extracted localStorage read/write helpers
  - normalized initial gate state
  - extracted email validation
  - kept the persisted shape and behavior unchanged

- Updated the chatbot email gate form
  - [src/pages/chatbot/EmailGate.jsx](/Users/johnnytrinh/.codex/worktrees/dec4/react-portfolio/src/pages/chatbot/EmailGate.jsx) now uses `onEmailChange` instead of receiving a raw state setter
  - [src/pages/chatbot/ChatbotMenu.jsx](/Users/johnnytrinh/.codex/worktrees/dec4/react-portfolio/src/pages/chatbot/ChatbotMenu.jsx) was updated to match

- Refactored [src/hooks/useContactForm.js](/Users/johnnytrinh/.codex/worktrees/dec4/react-portfolio/src/hooks/useContactForm.js)
  - extracted validation, sanitization, and EmailJS config lookup into small helpers
  - simplified submit flow
  - added concise comments around non-obvious logic

- Added form-level submit failure handling
  - the hook now exposes `submitError`
  - [src/pages/contact/ContactMenu.jsx](/Users/johnnytrinh/.codex/worktrees/dec4/react-portfolio/src/pages/contact/ContactMenu.jsx) renders the failure message for the user
  - existing field validation and success flow remain unchanged

## Why

The existing hooks were working, but they mixed storage, validation, sanitization, env lookup, and UI state transitions in ways that made them harder to reason about and extend safely.

This refactor keeps the same UX while making the logic easier to follow and easier to change later.

## Verification

- Confirmed the updated prop and state usage with targeted code search
- Attempted `npm run build`

Build status:
- `npm run build` could not complete in this environment because `react-scripts` is unavailable:
  - `sh: react-scripts: command not found`

## Notes

- `shared/profile.json` was synced to `public/profile.json` as part of the existing `prebuild` step
- No API contract changes
- No localStorage key changes
- No validation message changes
