### PR TITLE
xRefactor voice assistant hook lifecycle

### DIFF
--- a/src/hooks/useVoiceAssistant.js
+++ b/src/hooks/useVoiceAssistant.js
@@ -1,5 +1,16 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import Vapi from "@vapi-ai/web";
+
+const isFinalTranscriptMessage = (message) =>
+  message.type === "transcript" && message.transcriptType === "final";
+
+const isAssistantSpeechUpdate = (message) =>
+  message.type === "speech-update" && message.role === "assistant";
+
+const createTranscriptMessage = (message) => ({
+  role: message.role,
+  text: message.transcript,
+});
 
 const useVoiceAssistant = () => {
   const vapiRef = useRef(null);
@@ -10,40 +21,48 @@ const useVoiceAssistant = () => {
   const [messages, setMessages] = useState([]);
   const [isAssistantTyping, setIsAssistantTyping] = useState(false);
 
+  const resetCallState = useCallback(() => {
+    callRef.current = null;
+    setInCall(false);
+    setIsAssistantTyping(false);
+  }, []);
+
+  const handleCallStart = useCallback((call) => {
+    callRef.current = call;
+    setInCall(true);
+  }, []);
+
+  const handleVapiMessage = useCallback((message) => {
+    if (isFinalTranscriptMessage(message)) {
+      setMessages((prev) => [...prev, createTranscriptMessage(message)]);
+    }
+
+    if (isAssistantSpeechUpdate(message)) {
+      setIsAssistantTyping(message.status === "started");
+    }
+  }, []);
+
+  const handleCallEnd = useCallback(() => {
+    resetCallState();
+  }, [resetCallState]);
+
   useEffect(() => {
+    // Keep the Vapi client setup in one place so start/end actions only deal with call control.
     const vapi = new Vapi(process.env.REACT_APP_VAPI_PUBLIC_KEY);
     vapiRef.current = vapi;
 
-    vapi.on("call-start", (call) => {
-      callRef.current = call;
-      setInCall(true);
-    });
-
-    vapi.on("message", (msg) => {
-      if (msg.type === "transcript" && msg.transcriptType === "final") {
-        setMessages((prev) => [
-          ...prev,
-          { role: msg.role, text: msg.transcript },
-        ]);
-      }
-
-      if (msg.type === "speech-update" && msg.role === "assistant") {
-        setIsAssistantTyping(msg.status === "started");
-      }
-    });
-
-    vapi.on("call-end", () => {
-      callRef.current = null;
-      setInCall(false);
-      setIsAssistantTyping(false);
-    });
+    vapi.on("call-start", handleCallStart);
+    vapi.on("message", handleVapiMessage);
+    vapi.on("call-end", handleCallEnd);
 
     return () => {
       vapi.stop();
+      resetCallState();
     };
-  }, []);
+  }, [handleCallEnd, handleCallStart, handleVapiMessage, resetCallState]);
 
   useEffect(() => {
+    // Scroll the transcript as new final messages arrive.
     chatEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
 

--- a/src/hooks/useVoiceAssistant.test.js
+++ b/src/hooks/useVoiceAssistant.test.js
@@ -1,0 +1,103 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import Vapi from "@vapi-ai/web";
+import useVoiceAssistant from "./useVoiceAssistant";
+
+jest.mock("@vapi-ai/web", () => jest.fn());
+
+let mockVapiInstance;
+
+describe("useVoiceAssistant", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "error").mockImplementation(() => {});
+
+    process.env.REACT_APP_VAPI_PUBLIC_KEY = "public-key";
+    process.env.REACT_APP_VAPI_AGENT_ID = "agent-id";
+
+    Vapi.mockImplementation(function MockVapi() {
+      const handlers = {};
+
+      this.on = jest.fn((event, handler) => {
+        handlers[event] = handler;
+      });
+      this.start = jest.fn();
+      this.stop = jest.fn();
+      this.emit = (event, payload) => {
+        handlers[event]?.(payload);
+      };
+
+      mockVapiInstance = this;
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("creates the Vapi client and starts calls with the configured agent id", () => {
+    const { result } = renderHook(() => useVoiceAssistant());
+
+    expect(Vapi).toHaveBeenCalledWith("public-key");
+
+    act(() => {
+      result.current.startCall();
+    });
+
+    expect(mockVapiInstance.start).toHaveBeenCalledWith("agent-id");
+  });
+
+  it("appends final transcript messages and updates assistant typing state", async () => {
+    const { result } = renderHook(() => useVoiceAssistant());
+
+    act(() => {
+      mockVapiInstance.emit("message", {
+        type: "speech-update",
+        role: "assistant",
+        status: "started",
+      });
+    });
+
+    expect(result.current.isAssistantTyping).toBe(true);
+
+    act(() => {
+      mockVapiInstance.emit("message", {
+        type: "transcript",
+        transcriptType: "final",
+        role: "assistant",
+        transcript: "Hello there",
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.messages).toHaveLength(1);
+    });
+
+    expect(result.current.messages[0]).toEqual({
+      role: "assistant",
+      text: "Hello there",
+    });
+  });
+
+  it("resets call state when the call ends", () => {
+    const { result } = renderHook(() => useVoiceAssistant());
+
+    act(() => {
+      mockVapiInstance.emit("call-start", { id: "call-1" });
+      mockVapiInstance.emit("message", {
+        type: "speech-update",
+        role: "assistant",
+        status: "started",
+      });
+    });
+
+    expect(result.current.inCall).toBe(true);
+    expect(result.current.isAssistantTyping).toBe(true);
+
+    act(() => {
+      mockVapiInstance.emit("call-end");
+    });
+
+    expect(result.current.inCall).toBe(false);
+    expect(result.current.isAssistantTyping).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

This PR refactors `useVoiceAssistant` to separate Vapi setup, event handling, transcript creation, and call-state cleanup while keeping the public hook API and voice assistant UI behavior unchanged.

## Scope

Files touched:
- `src/hooks/useVoiceAssistant.js`
- `src/hooks/useVoiceAssistant.test.js`

Primary responsibility cleaned up:
- voice assistant hook lifecycle and event orchestration

Why this scope is intentionally limited:
- no component API changes
- no UI redesign
- no Vapi integration redesign
- only the hook internals and targeted tests were updated

## What Changed

- extracted small message and event helpers
  - final transcript message detection
  - assistant speech-update detection
  - transcript message creation

- centralized call-state reset
  - clears active call state
  - clears assistant typing state

- extracted hook lifecycle handlers
  - call start
  - Vapi message handling
  - call end

- kept the Vapi setup effect focused on initialization and cleanup

- added short comments around:
  - Vapi setup responsibility
  - transcript scrolling behavior

- added targeted tests for:
  - Vapi client creation and `startCall`
  - final transcript message handling
  - assistant typing updates
  - call-end reset behavior

## What Did Not Change

- no public hook API changes
- no `VoiceAssistant` component API changes
- no UI copy changes
- no env variable renames
- no behavior changes to start/end call controls

## Verification

Ran:
- `npm test -- --watch=false --runInBand src/hooks/useVoiceAssistant.test.js`
- `npx eslint src/hooks/useVoiceAssistant.js src/hooks/useVoiceAssistant.test.js`

Result:
- 3 tests passed
- ESLint reported no rule violations

Additional note:
- ESLint printed the existing Browserslist notice:
  - `Browserslist: caniuse-lite is outdated`
- This did not fail linting, but it is worth a separate maintenance update later.

## Risks Or Follow-Up Work

- `VoiceAssistant.jsx` still owns some rendering orchestration that could be tightened later if needed
- the Browserslist/caniuse-lite notice should be handled in a separate maintenance PR, not bundled into this refactor
- broader integration testing for the live Vapi flow is still not present
