### PR TITLE
Refactor chat assistant orchestration

### DIFF
--- a/src/components/assistant/ChatAssistant.jsx
+++ b/src/components/assistant/ChatAssistant.jsx
@@ -8,8 +8,104 @@ import { matchChatPortfolioItems } from "../../utils/matchChatPortfolioItems";
 import ChatPortfolioCard from "./ChatPortfolioCard";
 import "../../styles/chatAssistant.css";
 
+const CHAT_ACHIEVEMENT_IDS = ["chat_messages", "conversation_starter"];
+
 const isExternalLink = (href = "") =>
   /^https?:\/\//i.test(href) || href.startsWith("//");
+
+const getMessageLabel = (sender) =>
+  `Message from ${sender === "ai" ? "Johnny's assistant" : "You"}`;
+
+const trackChatAchievements = (updateProgress) => {
+  CHAT_ACHIEVEMENT_IDS.forEach((id) => {
+    updateProgress(id);
+  });
+};
+
+const LiveStatus = () => (
+  <div className="chat-live-status" role="status" aria-live="polite">
+    <span className="chat-live-dot"></span>
+    Johnny's assistant is responding live...
+  </div>
+);
+
+const ChatMessage = ({ msg, projects, hackathons, onCtaClick }) => {
+  const matchedItems =
+    msg.sender === "ai" && !msg.isStreaming
+      ? matchChatPortfolioItems(msg.text, projects, hackathons) || []
+      : [];
+
+  return (
+    <div className={`chat-message ${msg.sender}`}>
+      <div
+        className={`chat-bubble ${msg.sender} ${
+          msg.isStreaming ? "streaming" : ""
+        }`}
+        role="article"
+        aria-label={getMessageLabel(msg.sender)}
+      >
+        <div className="chat-markdown">
+          <ReactMarkdown
+            components={{
+              a: ({ href, children, ...props }) => {
+                const external = isExternalLink(href);
+
+                return (
+                  <a
+                    {...props}
+                    href={href}
+                    target={external ? "_blank" : undefined}
+                    rel={external ? "noopener noreferrer" : undefined}
+                  >
+                    {children}
+                  </a>
+                );
+              },
+            }}
+          >
+            {msg.text}
+          </ReactMarkdown>
+        </div>
+        {msg.sender === "ai" && !msg.isStreaming && msg.ctas?.length > 0 ? (
+          <div className="chat-cta-group">
+            {msg.ctas.map((cta) => (
+              <button
+                key={cta.route}
+                type="button"
+                className="chat-cta-button"
+                onClick={() => onCtaClick(cta.route)}
+                aria-label={cta.label}
+              >
+                {cta.label}
+              </button>
+            ))}
+          </div>
+        ) : null}
+      </div>
+      {matchedItems.map((item) => (
+        <ChatPortfolioCard key={`${item.type}:${item.title}`} item={item} />
+      ))}
+    </div>
+  );
+};
+
+const SuggestionButtons = ({ suggestions, onSuggestionClick }) => (
+  <div
+    className="suggestion-buttons"
+    role="group"
+    aria-label="Suggested questions"
+  >
+    {suggestions.map((suggestion, index) => (
+      <button
+        key={index}
+        onClick={() => onSuggestionClick(suggestion)}
+        aria-label={`Send suggested message: ${suggestion}`}
+      >
+        {suggestion}
+      </button>
+    ))}
+  </div>
+);
 
 const ChatAssistant = () => {
   const location = useLocation();
@@ -29,25 +125,22 @@ const ChatAssistant = () => {
   const { projects, hackathons } = useProfileData();
   const followUpSuggestions = getSuggestionsByRoute(location.pathname);
   const isStreaming = loading || messages.some((message) => message.isStreaming);
+  const shouldShowSuggestions =
+    followUpSuggestions.length > 0 && messages.length <= 2;
 
   const handleCtaClick = (route) => {
     navigate(route);
   };
 
-  // Track chat message achievements
+  // Keep achievement updates in one place so typed and suggested prompts stay aligned.
   const handleSendWithTracking = () => {
     handleSendMessage();
-    // Update both chat achievements
-    updateProgress("chat_messages"); // For 5 messages achievement
-    updateProgress("conversation_starter"); // For 10 messages achievement
+    trackChatAchievements(updateProgress);
   };
 
-  // Track suggestion button messages
   const handleSuggestionClick = (suggestion) => {
     sendMessage(suggestion);
-    // Update both chat achievements
-    updateProgress("chat_messages"); // For 5 messages achievement
-    updateProgress("conversation_starter"); // For 10 messages achievement
+    trackChatAchievements(updateProgress);
   };
 
   return (
@@ -57,86 +150,23 @@ const ChatAssistant = () => {
       aria-label="Johnny's Chat Assistant"
     >
       <div className={`chat-box ${isStreaming ? "live" : ""}`} role="log" aria-live="polite">
-          {isStreaming ? (
-            <div className="chat-live-status" role="status" aria-live="polite">
-              <span className="chat-live-dot"></span>
-              Johnny's assistant is responding live...
-            </div>
-          ) : null}
-          {messages.map((msg) => (
-            <div key={msg.id} className={`chat-message ${msg.sender}`}>
-              <div
-                className={`chat-bubble ${msg.sender} ${
-                  msg.isStreaming ? "streaming" : ""
-                }`}
-                role="article"
-                aria-label={`Message from ${
-                  msg.sender === "ai" ? "Johnny's assistant" : "You"
-                }`}
-              >
-                <div className="chat-markdown">
-                  <ReactMarkdown
-                    components={{
-                      a: ({ href, children, ...props }) => {
-                        const external = isExternalLink(href);
-
-                        return (
-                          <a
-                            {...props}
-                            href={href}
-                            target={external ? "_blank" : undefined}
-                            rel={external ? "noopener noreferrer" : undefined}
-                          >
-                            {children}
-                          </a>
-                        );
-                      },
-                    }}
-                  >
-                    {msg.text}
-                  </ReactMarkdown>
-                </div>
-                {msg.sender === "ai" && !msg.isStreaming && msg.ctas?.length > 0 ? (
-                  <div className="chat-cta-group">
-                    {msg.ctas.map((cta) => (
-                      <button
-                        key={cta.route}
-                        type="button"
-                        className="chat-cta-button"
-                        onClick={() => handleCtaClick(cta.route)}
-                        aria-label={cta.label}
-                      >
-                        {cta.label}
-                      </button>
-                    ))}
-                  </div>
-                ) : null}
-              </div>
-              {msg.sender === "ai" && !msg.isStreaming
-                ? matchChatPortfolioItems(msg.text, projects, hackathons).map(
-                    (item) => <ChatPortfolioCard key={`${item.type}:${item.title}`} item={item} />
-                  )
-                : null}
-            </div>
-          ))}
-          <div ref={chatEndRef} />
-          {followUpSuggestions.length > 0 && messages.length <= 2 && (
-            <div
-              className="suggestion-buttons"
-              role="group"
-              aria-label="Suggested questions"
-            >
-              {followUpSuggestions.map((suggestion, index) => (
-                <button
-                  key={index}
-                  onClick={() => handleSuggestionClick(suggestion)}
-                  aria-label={`Send suggested message: ${suggestion}`}
-                >
-                  {suggestion}
-                </button>
-              ))}
-            </div>
-          )}
+        {isStreaming ? <LiveStatus /> : null}
+        {messages.map((msg) => (
+          <ChatMessage
+            key={msg.id}
+            msg={msg}
+            projects={projects}
+            hackathons={hackathons}
+            onCtaClick={handleCtaClick}
+          />
+        ))}
+        <div ref={chatEndRef} />
+        {shouldShowSuggestions ? (
+          <SuggestionButtons
+            suggestions={followUpSuggestions}
+            onSuggestionClick={handleSuggestionClick}
+          />
+        ) : null}
       </div>
       <div className="chat-input-container">
         <label htmlFor="chat-input" className="visually-hidden">

--- a/src/components/assistant/ChatAssistant.test.jsx
+++ b/src/components/assistant/ChatAssistant.test.jsx
@@ -1,0 +1,116 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import ChatAssistant from "./ChatAssistant";
+import useChatbot from "../../hooks/useChatbot";
+
+const mockNavigate = jest.fn();
+const mockHandleSendMessage = jest.fn();
+const mockClearChat = jest.fn();
+const mockSendMessage = jest.fn();
+const mockSetInput = jest.fn();
+const mockUpdateProgress = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  useLocation: () => ({ pathname: "/chatbot" }),
+  useNavigate: () => mockNavigate,
+}));
+jest.mock("react-markdown", () => ({ children }) => <>{children}</>);
+
+jest.mock("../../hooks/useChatbot", () => jest.fn());
+jest.mock("../../hooks/achievements/useAchievement", () => ({
+  useAchievements: () => ({
+    updateProgress: mockUpdateProgress,
+  }),
+}));
+jest.mock("../../hooks/useProfileData", () => () => ({
+  projects: [],
+  hackathons: [],
+}));
+jest.mock("../../utils/matchChatPortfolioItems", () => ({
+  matchChatPortfolioItems: jest.fn(() => []),
+}));
+jest.mock("./ChatPortfolioCard", () => () => <div>Portfolio Card</div>);
+
+describe("ChatAssistant", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    useChatbot.mockReturnValue({
+      messages: [
+        {
+          id: 1,
+          sender: "ai",
+          text: "Hello",
+          ctas: [{ label: "View Projects", route: "/projects" }],
+          isStreaming: false,
+        },
+      ],
+      loading: false,
+      input: "Tell me more",
+      setInput: mockSetInput,
+      handleSendMessage: mockHandleSendMessage,
+      clearChat: mockClearChat,
+      chatEndRef: { current: null },
+      sendMessage: mockSendMessage,
+    });
+  });
+
+  it("tracks achievements when sending a typed message", () => {
+    render(<ChatAssistant />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+
+    expect(mockHandleSendMessage).toHaveBeenCalled();
+    expect(mockUpdateProgress).toHaveBeenCalledWith("chat_messages");
+    expect(mockUpdateProgress).toHaveBeenCalledWith("conversation_starter");
+  });
+
+  it("navigates when a CTA button is clicked", () => {
+    render(<ChatAssistant />);
+
+    fireEvent.click(screen.getByRole("button", { name: "View Projects" }));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/projects");
+  });
+
+  it("sends suggestion prompts and tracks achievements", () => {
+    useChatbot.mockReturnValue({
+      messages: [
+        {
+          id: 1,
+          sender: "ai",
+          text: "Hello",
+          ctas: [],
+          isStreaming: false,
+        },
+        {
+          id: 2,
+          sender: "ai",
+          text: "Try a suggestion",
+          ctas: [],
+          isStreaming: false,
+        },
+      ],
+      loading: false,
+      input: "",
+      setInput: mockSetInput,
+      handleSendMessage: mockHandleSendMessage,
+      clearChat: mockClearChat,
+      chatEndRef: { current: null },
+      sendMessage: mockSendMessage,
+    });
+
+    render(<ChatAssistant />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Send suggested message: What projects has Johnny built?",
+      })
+    );
+
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      "What projects has Johnny built?"
+    );
+    expect(mockUpdateProgress).toHaveBeenCalledWith("chat_messages");
+    expect(mockUpdateProgress).toHaveBeenCalledWith("conversation_starter");
+  });
+});


### PR DESCRIPTION
## Summary

This PR refactors `ChatAssistant` to separate rendering concerns from chat orchestration while keeping the existing UI behavior and hook integrations unchanged.

## Scope

Files touched:
- `src/components/assistant/ChatAssistant.jsx`
- `src/components/assistant/ChatAssistant.test.jsx`

Primary responsibility cleaned up:
- chat assistant component orchestration and rendering structure

Why this scope is intentionally limited:
- no hook API changes
- no UI redesign
- no chat flow changes
- only the component structure and targeted tests were updated

## What Changed

- extracted small component-level helpers:
  - `LiveStatus`
  - `ChatMessage`
  - `SuggestionButtons`

- extracted shared orchestration helpers:
  - message accessibility label helper
  - centralized achievement tracking helper

- reduced repeated logic for:
  - typed-message achievement updates
  - suggestion-message achievement updates
  - message rendering branches
  - suggestion rendering conditions

- added a defensive fallback so matched portfolio cards always resolve from an array

- added targeted tests for:
  - typed send achievement tracking
  - CTA navigation
  - suggestion-click sending and achievement tracking

## What Did Not Change

- no `useChatbot` API changes
- no `ChatAssistant` UI redesign
- no route suggestion content changes
- no portfolio card matching behavior changes
- no navigation behavior changes
- no assistant message copy changes

## Verification

Ran:
- `npm test -- --watch=false --runInBand src/components/assistant/ChatAssistant.test.jsx`
- `npx eslint src/components/assistant/ChatAssistant.jsx src/components/assistant/ChatAssistant.test.jsx`

Result:
- 3 tests passed
- ESLint reported no rule violations

Additional note:
- ESLint printed the existing Browserslist notice:
  - `Browserslist: caniuse-lite is outdated`
- This did not fail verification, but it should be handled separately as maintenance work.

## Risks Or Follow-Up Work

- the Browserslist/caniuse-lite notice remains and should be addressed in a separate maintenance PR
- if we continue refactoring this area, the next likely target is broader app-shell or assistant-flow composition rather than this component again
- integration coverage across `ChatAssistant` + `useChatbot` together is still limited
